### PR TITLE
Add links to core tidyverse packages

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -57,7 +57,7 @@ Install the complete tidyverse with a single line of code:
 install.packages("tidyverse")
 ```
 
-Load the __core__ tidyverse packages: ggplot2, tibble, tidyr, [readr](http://readr.tidyverse.org), purrr, and dplyr. These are the packages you are likely to use in almost every analyis.
+Load the __core__ tidyverse packages: [ggplot2](http://ggplot2.tidyverse.org), [tibble](http://tibble.tidyverse.org), [tidyr](http://tidyr.tidyverse.org), [readr](http://readr.tidyverse.org), [purrr](http://purrr.tidyverse.org), and [dplyr](http://dplyr.tidyverse.org). These are the packages you are likely to use in almost every analyis.
 
 ```{r}
 library(tidyverse)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install the complete tidyverse with a single line of code:
 install.packages("tidyverse")
 ```
 
-Load the **core** tidyverse packages: ggplot2, tibble, tidyr, [readr](http://readr.tidyverse.org), purrr, and dplyr. These are the packages you are likely to use in almost every analyis.
+Load the **core** tidyverse packages: [ggplot2](http://ggplot2.tidyverse.org), [tibble](http://tibble.tidyverse.org), [tidyr](http://tidyr.tidyverse.org), [readr](http://readr.tidyverse.org), [purrr](http://purrr.tidyverse.org), and [dplyr](http://dplyr.tidyverse.org). These are the packages you are likely to use in almost every analyis.
 
 ``` r
 library(tidyverse)

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -51,7 +51,9 @@
     </div>
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav navbar-right">
-        
+        <li>
+  <a href="reference/index.html">Reference</a>
+</li>
         
       </ul>
     </div><!--/.nav-collapse -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,12 @@
       </div>
     </div>
     <div id="navbar" class="navbar-collapse collapse">
-      <ul class="nav navbar-nav navbar-right"></ul>
+      <ul class="nav navbar-nav navbar-right">
+<li>
+  <a href="reference/index.html">Reference</a>
+</li>
+        
+      </ul>
 </div>
 <!--/.nav-collapse -->
   </div>
@@ -67,7 +72,7 @@ small.tidyverse {display: none;}
 <a href="#installation" class="anchor"></a>Installation</h2>
 <p>Install the complete tidyverse with a single line of code:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">install.packages</span>(<span class="st">"tidyverse"</span>)</code></pre></div>
-<p>Load the <strong>core</strong> tidyverse packages: ggplot2, tibble, tidyr, <a href="http://readr.tidyverse.org">readr</a>, purrr, and dplyr. These are the packages you are likely to use in almost every analyis.</p>
+<p>Load the <strong>core</strong> tidyverse packages: <a href="http://ggplot2.tidyverse.org">ggplot2</a>, <a href="http://tibble.tidyverse.org">tibble</a>, <a href="http://tidyr.tidyverse.org">tidyr</a>, <a href="http://readr.tidyverse.org">readr</a>, <a href="http://purrr.tidyverse.org">purrr</a>, and <a href="http://dplyr.tidyverse.org">dplyr</a>. These are the packages you are likely to use in almost every analyis.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">library</span>(tidyverse)
 <span class="co">#&gt; Loading tidyverse: ggplot2</span>
 <span class="co">#&gt; Loading tidyverse: tibble</span>


### PR DESCRIPTION
The current version of the page links to only one package (readr) in the body text. For consistency, added links to ggplot2, tibble, tidyr, purrr, and dplyr.